### PR TITLE
Fix logout clearing wrong storage key

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -49,7 +49,9 @@ function App() {
   if (loading) return <p>Se încarcă voturile...</p>;
 
   const handleLogout = () => {
-    localStorage.removeItem("cnp_user");
+    // Elimina CNP-ul salvat la autentificare si starea de vot
+    localStorage.removeItem("votCNP");
+    localStorage.removeItem("hasVoted");
     setCnp(null); // trimite la componenta de autentificare
   };
 


### PR DESCRIPTION
## Summary
- fix logout so saved CNP and voting state are removed

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403cc643bc832db7ba7eeab7247950