### PR TITLE
Add image to voting card

### DIFF
--- a/frontend/src/componente/OptiuniVot.js
+++ b/frontend/src/componente/OptiuniVot.js
@@ -32,6 +32,11 @@ function OptiuniVot({ optiune, voturi, cnp, onVote, aVotat }) {
 
   return (
     <Card className="mb-3 shadow-sm">
+      <Card.Img
+        variant="top"
+        src="/images/vote-bg.jpg"
+        alt={`Imagine ${optiune}`}
+      />
       <Card.Body>
         <Card.Title>{optiune}</Card.Title>
         <Card.Text>{voturi} voturi</Card.Text>


### PR DESCRIPTION
## Summary
- display an image on each `OptiuniVot` card

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684851c59408832db9060a8a32cddf77